### PR TITLE
Add bdftopcf dependency for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Dependencies
 ------------
 
 - make (for easy installation)
+- bdftopcf (brew install xquartz on macOS)
 
 (Most UNIXes will have this pre-installed.)
 


### PR DESCRIPTION
`bdftopcf` is not included with macOS, but can easily be installed using `brew`.